### PR TITLE
add PythonDocs package

### DIFF
--- a/unreleased-packages.json
+++ b/unreleased-packages.json
@@ -13,6 +13,16 @@
             ]
         },
         {
+            "name": "PythonDocs",
+            "details": "https://github.com/gwenzek/PythonDocs",
+            "releases": [
+                {
+                    "sublime_text": ">=4106",
+                    "tags": true
+                }
+            ]
+        },  
+        {
             "name": "ProjectSpecificKeys",
             "details": "https://github.com/OdatNurd/ProjectSpecificKeys",
             "releases": [


### PR DESCRIPTION
PythonDocs require hyperhelp so users will need to add this repository anyway.