### PR TITLE
Prepare to officially release EnhancedSnippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ as well as providing an alternate channel for packages currently under
 development.
 
 The [packages.json](packages.json) file is directly included by Package
-Control, which makes all packages defined within it directyly available to
+Control, which makes all packages defined within it directly available to
 every Package Control user.
 
 The [unreleased-packages.json](unreleased-packages.json) file is an additional

--- a/packages.json
+++ b/packages.json
@@ -16,6 +16,20 @@
             ]
         },
         {
+            "name": "EnhancedSnippets",
+            "details": "https://github.com/STealthy-and-haSTy/EnhancedSnippets",
+            "readme": "https://raw.githubusercontent.com/STealthy-and-haSTy/EnhancedSnippets/master/README.md",
+            "homepage": "https://enhancedsnippets.odatnurd.net/",
+            "author": "OdatNurd",
+            "labels": ["snippet", "snippets", "completion", "completions", "yaml snippet"],
+            "releases": [
+                {
+                    "sublime_text": ">=4073",
+                    "tags": true
+                }
+            ]
+        },
+        {
             "name": "OverrideAudit",
             "details": "https://github.com/OdatNurd/OverrideAudit",
             "readme": "https://raw.githubusercontent.com/OdatNurd/OverrideAudit/stable/README.md",

--- a/unreleased-packages.json
+++ b/unreleased-packages.json
@@ -3,16 +3,6 @@
 
     "packages": [
         {
-            "name": "EnhancedSnippets",
-            "details": "https://github.com/STealthy-and-haSTy/EnhancedSnippets",
-            "releases": [
-                {
-                    "sublime_text": ">=4073",
-                    "tags": true
-                }
-            ]
-        },        
-        {
             "name": "HyperHelpAuthor",
             "details": "https://github.com/STealthy-and-haSTy/HyperHelpAuthor",
             "releases": [


### PR DESCRIPTION
This commit jumps EnhancedSnippets from the unreleased to released channels.

Along the way the channel entry was fleshed out to better match the officially released packages in the channel (e.g. including a more explicit README link).
